### PR TITLE
refactor: 증권(security) 엔티티 변경

### DIFF
--- a/src/app/krx-test/StockCard.tsx
+++ b/src/app/krx-test/StockCard.tsx
@@ -5,8 +5,8 @@ interface Props {
 }
 
 export function StockCard({ stock }: Props) {
-  const price = stock.regularMarketPrice ?? 0;
-  const changePercent = stock.regularMarketChangePercent ?? 0;
+  const price = stock.price ?? 0;
+  const changePercent = stock.changePercent ?? 0;
   const isUp = changePercent > 0;
   const isDown = changePercent < 0;
 
@@ -30,7 +30,7 @@ export function StockCard({ stock }: Props) {
       {/* 헤더 섹션 */}
       <div className="flex items-start justify-between mb-6">
         <div className="bg-light-gray-5 rounded-xl p-4 flex-1 mr-3">
-          <h3 className="text-xl font-bold text-light-gray-90 mb-2 leading-tight">{stock.shortName}</h3>
+          <h3 className="text-xl font-bold text-light-gray-90 mb-2 leading-tight">{stock.name}</h3>
           <p className="text-sm text-light-gray-60 font-semibold">{stock.symbol}</p>
         </div>
         <div className="w-4 h-4 bg-light-success-50 rounded-full animate-pulse shadow-lg"></div>

--- a/src/core/entities/security.entity.ts
+++ b/src/core/entities/security.entity.ts
@@ -1,113 +1,25 @@
-/**
- * 금융 상품(주식, ETF 등)의 핵심 정보를 나타내는 데이터 구조입니다.
- * yfinance 응답 데이터를 기반으로 애플리케이션에서 사용할 주요 필드를 정의합니다.
- */
 export interface Security {
-  /**
-   * 종목 코드 (Ticker Symbol)
-   * @example 'AAPL', '005930.KS'
-   */
-  symbol: string;
+  // 식별 정보
+  symbol: string; // 종목 코드 (005930, AAPL) - 중복되지 않는 고유 식별자
+  isin?: string; // ISIN (국제증권식별번호) - 확장성을 위해
+  name: string; // 종목명 (삼성전자, Apple Inc.)
 
-  /**
-   * 종목 약칭
-   * @example 'Apple Inc.', 'Samsung Electronics Co., Ltd.'
-   */
-  shortName: string;
+  // 시세 정보
+  price: number; // 현재가
+  change: number; // 등락액
+  changePercent: number; // 등락률
+  previousClose?: number; // 전일 종가
+  open?: number; // 시가
+  high?: number; // 고가
+  low?: number; // 저가
+  volume?: number; // 거래량
 
-  /**
-   * 종목 전체 이름
-   */
-  longName?: string;
+  // 시장 정보
+  market: "KOSPI" | "KOSDAQ" | "NASDAQ" | "NYSE" | "ETF"; // 시장 구분
+  currency: "KRW" | "USD"; // 통화
+  country: "KR" | "US"; // 국가
 
-  /**
-   * 통화 단위
-   * @example 'USD', 'KRW'
-   */
-  currency: string;
-
-  /**
-   * 정규 시장의 현재 또는 종가
-   */
-  regularMarketPrice: number;
-
-  /**
-   * 정규 시장의 가격 변동액
-   */
-  regularMarketChange: number;
-
-  /**
-   * 정규 시장의 가격 변동률 (%)
-   */
-  regularMarketChangePercent: number;
-
-  /**
-   * 정규 시장의 전일 종가
-   */
-  regularMarketPreviousClose: number;
-
-  /**
-   * 정규 시장의 시가
-   */
-  regularMarketOpen: number;
-
-  /**
-   * 정규 시장의 당일 고가
-   */
-  regularMarketDayHigh: number;
-
-  /**
-   * 정규 시장의 당일 저가
-   */
-  regularMarketDayLow: number;
-
-  /**
-   * 정규 시장의 당일 거래량
-   */
-  regularMarketVolume: number;
-
-  /**
-   * 시가총액
-   */
-  marketCap: number;
-
-  /**
-   * 후행 주가수익비율 (Trailing P/E)
-   */
-  trailingPE?: number;
-
-  /**
-   * 선행 주가수익비율 (Forward P/E)
-   */
-  forwardPE?: number;
-
-  /**
-   * 주당순이익 (지난 12개월)
-   */
-  epsTrailingTwelveMonths?: number;
-
-  /**
-   * 주가순자산비율 (PBR)
-   */
-  priceToBook?: number;
-
-  /**
-   * 52주 최고가
-   */
-  fiftyTwoWeekHigh: number;
-
-  /**
-   * 52주 최저가
-   */
-  fiftyTwoWeekLow: number;
-
-  /**
-   * 3개월 평균 일일 거래량
-   */
-  averageDailyVolume3Month: number;
-
-  /**
-   * 마지막 거래 시점의 타임스탬프
-   */
-  regularMarketTime: Date;
+  // 추가 정보
+  marketCap?: number; // 시가총액
+  source: "KRX" | "KIS" | "yfinance"; // 데이터 출처
 }

--- a/src/core/repositories/_security.krx.repository.ts
+++ b/src/core/repositories/_security.krx.repository.ts
@@ -72,14 +72,17 @@ async function downloadAndParseSecurities(otp: string, market: "KOSPI" | "KOSDAQ
   });
 
   return parsed.data.map((row) => ({
-    symbol: `${row["종목코드"]}.KS`,
-    shortName: row["종목명"],
+    symbol: row["종목코드"],
+    name: row["종목명"],
+    price: safeParseFloat(row["종가"]),
+    change: safeParseFloat(row["대비"]),
+    changePercent: safeParseFloat(row["등락률"]),
     market: market,
-    regularMarketPrice: safeParseFloat(row["종가"]),
-    regularMarketChange: safeParseFloat(row["대비"]),
-    regularMarketChangePercent: safeParseFloat(row["등락률"]),
+    currency: "KRW",
+    country: "KR",
+    source: "KRX",
+    volume: safeParseFloat(row["거래량"]),
     marketCap: safeParseFloat(row["시가총액"]),
-    regularMarketVolume: safeParseFloat(row["거래량"]),
   }));
 }
 


### PR DESCRIPTION
## Result
```ts
export interface Security {
  // 식별 정보
  symbol: string; // 종목 코드 (005930, AAPL) - 중복되지 않는 고유 식별자
  isin?: string; // ISIN (국제증권식별번호) - 확장성을 위해
  name: string; // 종목명 (삼성전자, Apple Inc.)

  // 시세 정보
  price: number; // 현재가
  change: number; // 등락액
  changePercent: number; // 등락률
  previousClose?: number; // 전일 종가
  open?: number; // 시가
  high?: number; // 고가
  low?: number; // 저가
  volume?: number; // 거래량

  // 시장 정보
  market: "KOSPI" | "KOSDAQ" | "NASDAQ" | "NYSE" | "ETF"; // 시장 구분
  currency: "KRW" | "USD"; // 통화
  country: "KR" | "US"; // 국가

  // 추가 정보
  marketCap?: number; // 시가총액
  source: "KRX" | "KIS" | "yfinance"; // 데이터 출처
}

```

## Work list
- 보다 범용적으로 활용 가능하도록 증권 enitiy 관련 interface 변경
- 변경된 엔티티에 맞춰서 해당 데이터가 활용되는 컴포넌트`(StockCard)` 수정

## Discussion
