### PR TITLE
[Feat] rss feed 목록 조회 기능 구현

### DIFF
--- a/src/app/api/news/config/sources.ts
+++ b/src/app/api/news/config/sources.ts
@@ -1,0 +1,51 @@
+export interface RSSSource {
+  id: string;
+  name: string;
+  url: string;
+  category: "경제일반" | "증권" | "부동산" | "글로벌";
+  priority: number;
+  active: boolean;
+}
+
+export const RSS_SOURCES: RSSSource[] = [
+  {
+    id: "mk-stock",
+    name: "매일경제 증권",
+    url: "https://mk.co.kr/rss/50200011/",
+    category: "증권",
+    priority: 1,
+    active: true,
+  },
+  {
+    id: "hankyung-economy",
+    name: "한국경제 경제",
+    url: "https://www.hankyung.com/feed/economy",
+    category: "경제일반",
+    priority: 1,
+    active: true,
+  },
+  {
+    id: "hankyung-finance",
+    name: "한국경제 증권",
+    url: "https://www.hankyung.com/feed/finance",
+    category: "증권",
+    priority: 1,
+    active: true,
+  },
+  {
+    id: "chosun",
+    name: "조선비즈",
+    url: "https://biz.chosun.com/rss/biz.xml",
+    category: "경제일반",
+    priority: 2,
+    active: true,
+  },
+];
+
+export function getRSSSourceById(id: string): RSSSource | undefined {
+  return RSS_SOURCES.find((source) => source.id === id);
+}
+
+export function getActiveRSSSources(): RSSSource[] {
+  return RSS_SOURCES.filter((source) => source.active);
+}

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -1,37 +1,87 @@
 import { NextRequest, NextResponse } from "next/server";
+import { News } from "@/core/entities/news.entity";
 import { fetchRSSFeed } from "@/core/repositories/news.repository";
 import { parseRSSFeed } from "@/core/services/news.service";
-
-// RSS URL에서 데이터를 가져와서 파싱하는 조합 함수
-async function fetchAndParseRSS(url: string) {
-  const xmlData = await fetchRSSFeed(url);
-  return await parseRSSFeed(xmlData);
-}
+import { getActiveRSSSources, RSSSource } from "./config/sources";
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const url = searchParams.get("url");
-
-  if (!url) {
-    return NextResponse.json({ error: "RSS URL이 필요합니다. ?url=파라미터를 추가해주세요." }, { status: 400 });
-  }
-
-  // URL 유효성 검사
   try {
-    new URL(url);
-  } catch {
-    return NextResponse.json({ error: "유효하지 않은 URL입니다." }, { status: 400 });
-  }
+    const { searchParams } = new URL(request.url);
 
-  try {
-    const data = await fetchAndParseRSS(url);
-    return NextResponse.json({
-      url,
-      data,
-    });
+    const activeSources = getActiveRSSSources();
+    const filteredSources = filterRSSSourcesFromQuery(activeSources, searchParams);
+
+    const results = await processMultipleRSSSources(filteredSources);
+    const { allNews, errors } = separateNewsAndErrors(results, filteredSources);
+
+    const sortedNews = sortNewsByDate(allNews);
+
+    return createSuccessResponse(sortedNews, filteredSources, errors);
   } catch (error) {
-    console.error(`[api/news] Failed to fetch and parse RSS:`, error);
-    const message = error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.";
-    return NextResponse.json({ error: message }, { status: 500 });
+    return createErrorResponse(error);
   }
+}
+
+// 요청 파라미터 파싱 및 소스 필터링 (통합)
+function filterRSSSourcesFromQuery(sources: RSSSource[], searchParams: URLSearchParams): RSSSource[] {
+  const sourceParam = searchParams.get("source");
+
+  if (!sourceParam) {
+    return sources; // 파라미터 없으면 전체 소스 반환
+  }
+
+  // 콤마로 분리하여 배열로 변환 (단일값도 배열로 처리)
+  const requestedSourceIds = sourceParam.split(",").map((id) => id.trim());
+
+  // config 배열에서 요청된 ID들과 매칭되는 소스만 필터링
+  return sources.filter((source) => requestedSourceIds.includes(source.id));
+}
+
+// 단일 RSS 소스 처리
+async function processRSSSource(source: RSSSource) {
+  const xmlData = await fetchRSSFeed(source.url);
+  const news = await parseRSSFeed(xmlData, source.name);
+  return { source: source.id, news };
+}
+
+// 여러 RSS 소스 병렬 처리
+async function processMultipleRSSSources(sources: RSSSource[]) {
+  return await Promise.allSettled(sources.map(processRSSSource));
+}
+
+// 처리 결과에서 뉴스와 에러 분리
+function separateNewsAndErrors(results: PromiseSettledResult<{ source: string; news: News[] }>[], sources: RSSSource[]) {
+  const allNews: News[] = [];
+  const errors: string[] = [];
+
+  results.forEach((result, index) => {
+    if (result.status === "fulfilled") {
+      allNews.push(...result.value.news);
+    } else {
+      errors.push(`${sources[index].name}: ${result.reason}`);
+    }
+  });
+
+  return { allNews, errors };
+}
+
+// 뉴스 정렬 (최신순)
+function sortNewsByDate(news: News[]): News[] {
+  return news.sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+}
+
+// 성공 응답 생성
+function createSuccessResponse(news: News[], sources: RSSSource[], errors: string[]) {
+  return NextResponse.json({
+    data: news,
+    sources: sources.map((s) => s.name),
+    errors: errors.length > 0 ? errors : undefined,
+  });
+}
+
+// 에러 응답 생성
+function createErrorResponse(error: unknown) {
+  console.error(`[api/news] RSS 처리 실패:`, error);
+  const message = error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.";
+  return NextResponse.json({ error: message }, { status: 500 });
 }

--- a/src/app/components/NewsCard.tsx
+++ b/src/app/components/NewsCard.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { News } from "@/core/entities/news.entity";
+
+interface NewsCardProps {
+  news: News;
+  onClick?: () => void;
+}
+
+export function NewsCard({ news, onClick }: NewsCardProps) {
+  const formatDate = (date: Date) => {
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    const minutes = Math.floor(diff / (1000 * 60));
+
+    if (hours < 1) {
+      return `${minutes}분 전`;
+    } else if (hours < 24) {
+      return `${hours}시간 전`;
+    } else {
+      return date.toLocaleDateString("ko-KR", {
+        month: "short",
+        day: "numeric",
+      });
+    }
+  };
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow cursor-pointer" onClick={onClick}>
+      {/* 헤더: 소스 + 날짜 */}
+      <div className="flex justify-between items-center mb-2">
+        <span className="text-sm font-medium text-blue-600 bg-blue-50 px-2 py-1 rounded">{news.source}</span>
+        <span className="text-xs text-gray-500">{formatDate(new Date(news.publishedAt))}</span>
+      </div>
+
+      {/* 제목 */}
+      <h3 className="text-lg font-semibold text-gray-900 mb-2 line-clamp-2 leading-tight">{news.title}</h3>
+
+      {/* 요약 */}
+      <p className="text-sm text-gray-600 line-clamp-3 mb-3">{news.summary}</p>
+
+      {/* 기자명 (있는 경우) */}
+      {news.author && <div className="text-xs text-gray-400">{news.author}</div>}
+    </div>
+  );
+}

--- a/src/app/components/StockCard.tsx
+++ b/src/app/components/StockCard.tsx
@@ -1,64 +1,69 @@
-import { Security } from "@/core/entities/security.entity";
+interface SecurityData {
+  name?: string;
+  symbol?: string;
+  code?: string;
+  price?: number;
+  currentPrice?: number;
+  changePercent?: number;
+  volume?: number;
+  marketCap?: number;
+}
 
 interface Props {
-  stock: Partial<Security>;
+  security: SecurityData;
   onClick?: () => void;
+  isSelected?: boolean;
   className?: string;
 }
 
-export function StockCard({ stock, onClick, className = "" }: Props) {
-  const price = stock.price ?? 0;
-  const changePercent = stock.changePercent ?? 0;
+export function StockCard({ security, onClick, isSelected, className = "" }: Props) {
+  const price = security.currentPrice ?? security.price ?? 0;
+  const changePercent = security.changePercent ?? 0;
   const isUp = changePercent > 0;
   const isDown = changePercent < 0;
 
   const formattedPrice = new Intl.NumberFormat("ko-KR").format(price);
   const formattedChangePercent = `${changePercent > 0 ? "+" : ""}${changePercent.toFixed(2)}%`;
 
-  // KRDS 토큰을 활용한 조건부 클래스
-  const changeColorClass = isUp
-    ? "bg-light-danger-50 text-light-danger-70 border-light-danger-20"
-    : isDown
-      ? "bg-light-primary-50 text-light-primary-70 border-light-primary-20"
-      : "bg-light-gray-10 text-light-gray-70 border-light-gray-20";
-
   const changeSymbol = isUp ? "▲" : isDown ? "▼" : "-";
 
   return (
     <div
-      className={`w-80 bg-light-gray-0 rounded-2xl shadow-lg border border-light-gray-20 p-6 m-4 hover:shadow-xl hover:-translate-y-1 transition-all duration-300 relative overflow-hidden ${onClick ? "cursor-pointer" : ""} ${className}`}
+      className={`w-80 bg-white rounded-lg shadow-md border border-gray-200 p-4 mb-4 hover:shadow-lg hover:-translate-y-1 transition-all duration-300 relative overflow-hidden ${onClick ? "cursor-pointer" : ""} ${isSelected ? "ring-2 ring-blue-500" : ""} ${className}`}
       onClick={onClick}
     >
       {/* 상단 컬러 스트라이프 */}
-      <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-light-primary-50 to-light-success-50"></div>
+      <div className={`absolute top-0 left-0 right-0 h-1 ${isUp ? "bg-red-500" : isDown ? "bg-blue-500" : "bg-gray-300"}`}></div>
 
       {/* 헤더 섹션 */}
-      <div className="flex items-start justify-between mb-6">
-        <div className="bg-light-gray-5 rounded-xl p-4 flex-1 mr-3">
-          <h3 className="text-xl font-bold text-light-gray-90 mb-2 leading-tight">{stock.name}</h3>
-          <p className="text-sm text-light-gray-60 font-semibold">{stock.symbol}</p>
+      <div className="flex items-start justify-between mb-4">
+        <div className="flex-1">
+          <h3 className="text-lg font-bold text-gray-900 mb-1 leading-tight">{security.name || "종목명"}</h3>
+          <p className="text-sm text-gray-600 font-medium">{security.code || security.symbol || "코드"}</p>
         </div>
-        <div className="w-4 h-4 bg-light-success-50 rounded-full animate-pulse shadow-lg"></div>
+        <div className="w-3 h-3 bg-green-500 rounded-full animate-pulse"></div>
       </div>
 
       {/* 가격 정보 섹션 */}
-      <div className="bg-light-gray-5 rounded-xl p-5 mb-5">
-        <div className="text-center mb-4">
-          <p className="text-3xl font-black text-light-gray-90 mb-1">{formattedPrice}</p>
-          <p className="text-sm text-light-gray-50 font-semibold">원</p>
+      <div className="bg-gray-50 rounded-lg p-4 mb-4">
+        <div className="text-center mb-3">
+          <p className="text-2xl font-bold text-gray-900 mb-1">{formattedPrice}</p>
+          <p className="text-xs text-gray-500 font-medium">원</p>
         </div>
 
-        <div className={`flex items-center justify-center px-4 py-3 rounded-full border-2 font-bold text-sm transition-all duration-200 hover:scale-105 ${changeColorClass}`}>
-          <span className="mr-2 text-base">{changeSymbol}</span>
+        <div
+          className={`flex items-center justify-center px-3 py-2 rounded-full border font-bold text-sm transition-all duration-200 ${isUp ? "bg-red-50 text-red-700 border-red-200" : isDown ? "bg-blue-50 text-blue-700 border-blue-200" : "bg-gray-50 text-gray-700 border-gray-200"}`}
+        >
+          <span className="mr-2">{changeSymbol}</span>
           <span>{formattedChangePercent}</span>
         </div>
       </div>
 
       {/* 하단 정보 바 */}
-      <div className="flex justify-between items-center bg-gradient-to-r from-light-gray-10 to-light-gray-5 rounded-lg px-4 py-3 text-sm">
-        <span className="text-light-gray-70 font-semibold">🔥 실시간</span>
-        <span className="flex items-center text-light-success-60 font-bold">
-          <div className="w-2 h-2 bg-light-success-50 rounded-full mr-2 animate-ping"></div>⚡ LIVE
+      <div className="flex justify-between items-center bg-gradient-to-r from-gray-100 to-gray-50 rounded-lg px-3 py-2 text-xs">
+        <span className="text-gray-700 font-medium">🔥 실시간</span>
+        <span className="flex items-center text-green-600 font-bold">
+          <div className="w-2 h-2 bg-green-500 rounded-full mr-1 animate-ping"></div>⚡ LIVE
         </span>
       </div>
     </div>

--- a/src/app/components/StockDetailView.tsx
+++ b/src/app/components/StockDetailView.tsx
@@ -1,116 +1,114 @@
 "use client";
 
-import { Security } from "@/core/entities/security.entity";
-
-interface Props {
-  stock: Partial<Security> | null;
+interface SecurityData {
+  name?: string;
+  symbol?: string;
+  code?: string;
+  price?: number;
+  currentPrice?: number;
+  changePercent?: number;
+  volume?: number;
+  marketCap?: number;
 }
 
-export function StockDetailView({ stock }: Props) {
-  if (!stock) {
+interface Props {
+  security: SecurityData;
+}
+
+export function StockDetailView({ security }: Props) {
+  if (!security) {
     return (
       <div className="h-full bg-white rounded-lg border border-gray-200 p-6">
         <h2 className="text-xl font-semibold text-gray-900 mb-6">종목 상세 정보</h2>
 
         <div className="space-y-6">
-          {/* 종목 선택 안내 */}
-          <div className="text-center py-12">
-            <div className="text-6xl mb-4">📊</div>
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">종목을 선택해주세요</h3>
-            <p className="text-gray-600">
-              왼쪽 목록에서 종목을 클릭하면
-              <br />
-              상세 정보와 차트를 확인할 수 있습니다.
-            </p>
-          </div>
-
-          {/* 오늘의 주요 뉴스 */}
-          <div className="bg-blue-50 rounded-lg p-4">
-            <h3 className="font-semibold text-blue-900 mb-3">📈 오늘의 주요 뉴스</h3>
-            <div className="space-y-2 text-sm text-blue-700">
-              <p>• 코스피, 외국인 매수세에 상승 출발</p>
-              <p>• 반도체 업종 강세 지속</p>
-              <p>• 달러 강세로 수출주 관심 증가</p>
-            </div>
+          <div className="text-center text-gray-500">
+            <div className="text-4xl mb-4">📊</div>
+            <p className="text-lg font-medium">종목을 선택해주세요</p>
+            <p className="text-sm">상세 정보를 확인할 수 있습니다</p>
           </div>
         </div>
       </div>
     );
   }
 
-  const formattedPrice = new Intl.NumberFormat("ko-KR").format(stock.price ?? 0);
-  const changePercent = stock.changePercent ?? 0;
+  const price = security.currentPrice || security.price || 0;
+  const changePercent = security.changePercent || 0;
   const isUp = changePercent > 0;
   const isDown = changePercent < 0;
 
   return (
     <div className="h-full bg-white rounded-lg border border-gray-200 p-6">
-      <div className="flex justify-between items-start mb-6">
+      <div className="border-b border-gray-200 pb-4 mb-6">
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">{security.name}</h2>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-gray-600">{security.code || security.symbol}</p>
+          </div>
+          <div className="text-right">
+            <div className="flex items-center space-x-3">
+              <span className="text-2xl font-bold">{price.toLocaleString()} 원</span>
+            </div>
+            <div className="flex items-center justify-end mt-1">
+              <span className={`text-lg font-semibold ${isUp ? "text-red-600" : isDown ? "text-blue-600" : "text-gray-600"}`}>
+                {changePercent > 0 ? "+" : ""}
+                {changePercent.toFixed(2)}%
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        {/* 주요 지표 */}
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">{stock.name}</h2>
-          <p className="text-gray-600">{stock.symbol}</p>
-        </div>
-        <div className="text-right">
-          <p className="text-2xl font-bold text-gray-900">{formattedPrice}원</p>
-          <p className={`text-lg font-semibold ${isUp ? "text-red-600" : isDown ? "text-blue-600" : "text-gray-600"}`}>
-            {changePercent > 0 ? "+" : ""}
-            {changePercent.toFixed(2)}%
-          </p>
-        </div>
-      </div>
-
-      {/* 탭 네비게이션 */}
-      <div className="flex space-x-1 mb-6 bg-gray-100 rounded-lg p-1">
-        <button className="flex-1 py-2 px-4 bg-white rounded-md text-sm font-medium text-gray-900 shadow-sm">차트</button>
-        <button className="flex-1 py-2 px-4 text-sm font-medium text-gray-600 hover:text-gray-900">뉴스</button>
-        <button className="flex-1 py-2 px-4 text-sm font-medium text-gray-600 hover:text-gray-900">재무정보</button>
-      </div>
-
-      {/* 차트 영역 */}
-      <div className="bg-gray-50 rounded-lg p-6 mb-6 h-64 flex items-center justify-center">
-        <div className="text-center text-gray-500">
-          <div className="text-4xl mb-2">📈</div>
-          <p>차트가 여기에 표시됩니다</p>
-          <p className="text-sm">(react-echarts 연동 예정)</p>
-        </div>
-      </div>
-
-      {/* 기본 정보 */}
-      <div className="grid grid-cols-2 gap-4">
-        <div className="bg-gray-50 rounded-lg p-4">
-          <h4 className="font-semibold text-gray-900 mb-2">시장 정보</h4>
-          <div className="space-y-1 text-sm">
-            <div className="flex justify-between">
-              <span className="text-gray-600">시장:</span>
-              <span className="font-medium">{stock.market || "KOSPI"}</span>
+          <h3 className="text-lg font-semibold text-gray-900 mb-3">주요 지표</h3>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="bg-gray-50 p-3 rounded-lg">
+              <p className="text-sm text-gray-600 mb-1">거래량</p>
+              <span className="text-gray-900 font-medium">{security.volume?.toLocaleString() || "N/A"}</span>
             </div>
-            <div className="flex justify-between">
-              <span className="text-gray-600">통화:</span>
-              <span className="font-medium">{stock.currency || "KRW"}</span>
+            <div className="bg-gray-50 p-3 rounded-lg">
+              <p className="text-sm text-gray-600 mb-1">시가총액</p>
+              <span className="text-gray-900 font-medium">{security.marketCap?.toLocaleString() || "N/A"}</span>
             </div>
           </div>
         </div>
 
-        <div className="bg-gray-50 rounded-lg p-4">
-          <h4 className="font-semibold text-gray-900 mb-2">거래 정보</h4>
-          <div className="space-y-1 text-sm">
-            <div className="flex justify-between">
-              <span className="text-gray-600">거래량:</span>
-              <span className="font-medium">{stock.volume ? new Intl.NumberFormat("ko-KR").format(stock.volume) : "-"}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-600">전일종가:</span>
-              <span className="font-medium">{stock.previousClose ? new Intl.NumberFormat("ko-KR").format(stock.previousClose) : "-"}</span>
-            </div>
+        {/* 차트 영역 */}
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 mb-3">차트</h3>
+          <div className="bg-gray-50 rounded-lg p-6 text-center">
+            <div className="text-4xl mb-2">📈</div>
+            <p className="text-gray-600">차트 영역</p>
+            <p className="text-sm text-gray-500 mt-1">실시간 차트가 표시됩니다</p>
           </div>
         </div>
-      </div>
 
-      {/* 액션 버튼 */}
-      <div className="mt-6 pt-6 border-t border-gray-200">
-        <div className="flex space-x-3">
-          <button className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium">관심종목 추가</button>
-          <button className="flex-1 bg-gray-100 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-200 transition-colors text-sm font-medium">실시간 정보 보기</button>
+        {/* 뉴스 영역 */}
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 mb-3">관련 뉴스</h3>
+          <div className="bg-gray-50 rounded-lg p-6 text-center">
+            <div className="text-4xl mb-2">📰</div>
+            <p className="text-gray-600">관련 뉴스</p>
+            <p className="text-sm text-gray-500 mt-1">종목 관련 뉴스가 표시됩니다</p>
+          </div>
+        </div>
+
+        {/* 재무 정보 */}
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 mb-3">재무 정보</h3>
+          <div className="bg-gray-50 rounded-lg p-6 text-center">
+            <div className="text-4xl mb-2">💼</div>
+            <p className="text-gray-600">재무 정보</p>
+            <p className="text-sm text-gray-500 mt-1">재무제표 데이터가 표시됩니다</p>
+          </div>
+        </div>
+
+        {/* 액션 버튼 */}
+        <div className="flex space-x-3 pt-4">
+          <button className="flex-1 bg-blue-500 text-white py-2 px-4 rounded-lg hover:bg-blue-600 transition-colors">관심종목 추가</button>
+          <button className="flex-1 bg-green-500 text-white py-2 px-4 rounded-lg hover:bg-green-600 transition-colors">상세 분석</button>
         </div>
       </div>
     </div>

--- a/src/app/market/hooks/useNewsData.ts
+++ b/src/app/market/hooks/useNewsData.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect } from "react";
+import { News } from "@/core/entities/news.entity";
+
+interface UseNewsDataReturn {
+  news: News[];
+  loading: boolean;
+  error: string | null;
+  fetchNewsData: () => Promise<void>;
+  clearNews: () => void;
+}
+
+export function useNewsData(autoFetch = true): UseNewsDataReturn {
+  const [news, setNews] = useState<News[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchNewsData = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/news?source=mk-stock,hankyung-economy,hankyung-finance");
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const newsData = await response.json();
+
+      if (newsData.data && Array.isArray(newsData.data)) {
+        setNews(newsData.data);
+      } else {
+        setNews([]);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "뉴스를 불러오는데 실패했습니다");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const clearNews = () => {
+    setNews([]);
+    setError(null);
+  };
+
+  // 자동 로드 기능
+  useEffect(() => {
+    if (autoFetch) {
+      fetchNewsData();
+    }
+  }, [autoFetch]);
+
+  return {
+    news,
+    loading,
+    error,
+    fetchNewsData,
+    clearNews,
+  };
+}

--- a/src/app/market/hooks/useStockData.ts
+++ b/src/app/market/hooks/useStockData.ts
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { Security } from "@/core/entities/security.entity";
+
+interface UseStockDataReturn {
+  stocks: Partial<Security>[];
+  loading: boolean;
+  error: string | null;
+  fetchStockData: () => Promise<void>;
+  clearStocks: () => void;
+}
+
+export function useStockData(): UseStockDataReturn {
+  const [stocks, setStocks] = useState<Partial<Security>[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStockData = async () => {
+    setLoading(true);
+    setError(null);
+    setStocks([]);
+
+    try {
+      const response = await fetch("/api/krx/securities?market=KOSPI");
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || "Failed to fetch data");
+      }
+      const data = await response.json();
+      setStocks(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "An unknown error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const clearStocks = () => {
+    setStocks([]);
+    setError(null);
+  };
+
+  return {
+    stocks,
+    loading,
+    error,
+    fetchStockData,
+    clearStocks,
+  };
+}

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useMemo, useState, useRef, useEffect } from "react";
+import React, { useMemo, useState, useRef, useEffect } from "react";
+import { News } from "@/core/entities/news.entity";
 import { Security } from "@/core/entities/security.entity";
 import { VirtualizedList } from "@/shared/components/VirtualizedList";
+import { NewsCard } from "../components/NewsCard";
 import { StockCard } from "../components/StockCard";
 import { StockDetailView } from "../components/StockDetailView";
 
@@ -22,6 +24,11 @@ export default function MarketPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedStock, setSelectedStock] = useState<Partial<Security> | null>(null);
+
+  // 뉴스 관련 상태
+  const [news, setNews] = useState<News[]>([]);
+  const [newsLoading, setNewsLoading] = useState(false);
+  const [newsError, setNewsError] = useState<string | null>(null);
 
   // 필터링 및 정렬을 위한 상태
   const [searchTerm, setSearchTerm] = useState("");
@@ -85,6 +92,73 @@ export default function MarketPage() {
     }
   };
 
+  // RSS 뉴스 데이터 불러오기
+  const fetchNewsData = async () => {
+    setNewsLoading(true);
+    setNewsError(null);
+    try {
+      console.log("📰 RSS Feed 데이터 가져오기 시작...");
+
+      const response = await fetch("/api/news?sources=mk-stock,hankyung-economy,hankyung-finance");
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const newsData = await response.json();
+      console.log("📰 뉴스 데이터 수신 성공:", newsData);
+      console.log("📰 뉴스 개수:", newsData.data?.length || 0);
+
+      if (newsData.data && Array.isArray(newsData.data)) {
+        setNews(newsData.data);
+        console.log("📰 첫 5개 뉴스:", newsData.data.slice(0, 5));
+      } else {
+        console.warn("📰 뉴스 데이터 형식이 예상과 다릅니다:", newsData);
+        setNews([]);
+      }
+    } catch (err) {
+      console.error("📰 RSS Feed 오류:", err);
+      setNewsError(err instanceof Error ? err.message : "뉴스를 불러오는데 실패했습니다");
+    } finally {
+      setNewsLoading(false);
+    }
+  };
+
+  // RSS 뉴스 API 테스트 (콘솔 로그용)
+  const testRSSFeedAPI = async () => {
+    try {
+      console.log("📰 RSS Feed API 테스트 시작...");
+
+      // 개별 소스 테스트 - 매일경제 증권
+      console.log("📰 매일경제 증권 단독 테스트...");
+      const mkResponse = await fetch("/api/news?source=mk-stock");
+      if (mkResponse.ok) {
+        const mkData = await mkResponse.json();
+        console.log("📰 매일경제 증권 뉴스:", mkData);
+        console.log("📰 매일경제 증권 뉴스 개수:", mkData.data?.length || 0);
+      }
+
+      // 개별 소스 테스트 - 한국경제 경제
+      console.log("📰 한국경제 경제 단독 테스트...");
+      const hankyungEconomyResponse = await fetch("/api/news?source=hankyung-economy");
+      if (hankyungEconomyResponse.ok) {
+        const hankyungEconomyData = await hankyungEconomyResponse.json();
+        console.log("📰 한국경제 경제 뉴스:", hankyungEconomyData);
+        console.log("📰 한국경제 경제 뉴스 개수:", hankyungEconomyData.data?.length || 0);
+      }
+
+      // 개별 소스 테스트 - 한국경제 증권
+      console.log("📰 한국경제 증권 단독 테스트...");
+      const hankyungFinanceResponse = await fetch("/api/news?source=hankyung-finance");
+      if (hankyungFinanceResponse.ok) {
+        const hankyungFinanceData = await hankyungFinanceResponse.json();
+        console.log("📰 한국경제 증권 뉴스:", hankyungFinanceData);
+        console.log("📰 한국경제 증권 뉴스 개수:", hankyungFinanceData.data?.length || 0);
+      }
+    } catch (err) {
+      console.error("📰 RSS Feed API 오류:", err);
+    }
+  };
+
   // 필터링 및 정렬 로직
   const processedStocks = useMemo(() => {
     let processableStocks = [...stocks];
@@ -136,6 +210,11 @@ export default function MarketPage() {
     setSelectedStock(stock);
   };
 
+  // 페이지 로드시 뉴스 데이터 불러오기
+  React.useEffect(() => {
+    fetchNewsData();
+  }, []);
+
   return (
     <div className="container mx-auto p-6 min-h-full">
       <div className="mb-6">
@@ -154,7 +233,15 @@ export default function MarketPage() {
           {/* 컨트롤 영역 */}
           <div className="flex flex-wrap gap-2 mb-4">
             <button onClick={handleFetchKrxData} disabled={loading} className="bg-blue-500 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded disabled:bg-gray-400 text-sm">
-              {loading ? "로딩 중..." : "데이터 불러오기"}
+              {loading ? "로딩 중..." : "종목 데이터 불러오기"}
+            </button>
+
+            <button onClick={fetchNewsData} disabled={newsLoading} className="bg-green-500 hover:bg-green-700 text-white font-medium py-2 px-4 rounded disabled:bg-gray-400 text-sm">
+              {newsLoading ? "뉴스 로딩중..." : "뉴스 불러오기"}
+            </button>
+
+            <button onClick={testRSSFeedAPI} className="bg-yellow-500 hover:bg-yellow-700 text-white font-medium py-2 px-4 rounded text-sm">
+              API 테스트 (콘솔)
             </button>
 
             <input
@@ -192,7 +279,7 @@ export default function MarketPage() {
                 containerHeight={containerHeight}
                 renderItem={(stock) => (
                   <div className="flex justify-center items-center h-full">
-                    <StockCard stock={stock} onClick={() => handleStockClick(stock)} className="hover:scale-105" />
+                    <StockCard security={stock} onClick={() => handleStockClick(stock)} className="hover:scale-105" />
                   </div>
                 )}
               />
@@ -207,8 +294,55 @@ export default function MarketPage() {
         </div>
 
         {/* Detail: 상세 정보 */}
-        <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
-          <StockDetailView stock={selectedStock} />
+        <div className="flex flex-col gap-6">
+          {/* 선택된 종목 정보 */}
+          <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+            {selectedStock ? (
+              <StockDetailView security={selectedStock} />
+            ) : (
+              <div className="flex items-center justify-center h-48 text-gray-500">
+                <div className="text-center">
+                  <div className="text-4xl mb-4">📊</div>
+                  <p className="text-lg font-medium">종목을 선택해주세요</p>
+                  <p className="text-sm">상세 정보를 확인할 수 있습니다</p>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* 뉴스 섹션 */}
+          <div className="bg-white rounded-lg border border-gray-200 p-4">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="text-lg font-semibold text-gray-900">실시간 뉴스</h3>
+              <span className="text-sm text-gray-500">매일경제 증권 · 한국경제 경제/증권</span>
+            </div>
+
+            {newsError && (
+              <div className="mb-4 p-3 bg-red-100 text-red-700 border border-red-400 rounded text-sm">
+                <p className="font-semibold">뉴스 로딩 오류:</p>
+                <p>{newsError}</p>
+              </div>
+            )}
+
+            {newsLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <div className="text-gray-500">뉴스를 불러오는 중...</div>
+              </div>
+            ) : news.length > 0 ? (
+              <div className="space-y-3 max-h-96 overflow-y-auto">
+                {news.map((newsItem) => (
+                  <NewsCard key={newsItem.id} news={newsItem} onClick={() => window.open(newsItem.url, "_blank")} />
+                ))}
+                <div className="text-center py-2 text-xs text-gray-400">총 {news.length}개의 뉴스</div>
+              </div>
+            ) : (
+              <div className="text-center py-8 text-gray-500">
+                <div className="text-4xl mb-2">📰</div>
+                <p>뉴스 데이터가 없습니다</p>
+                <p className="text-sm mt-1">뉴스 불러오기 버튼을 클릭해보세요</p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/core/entities/news.entity.ts
+++ b/src/core/entities/news.entity.ts
@@ -1,0 +1,9 @@
+export interface News {
+  id: string; // 고유 식별자
+  title: string; // 기사 제목
+  summary: string; // 기사 요약
+  url: string; // 원문 링크
+  publishedAt: Date; // 발행일시
+  source: string; // 데이터 소스
+  author?: string; // 기자명
+}

--- a/src/core/types/security.type.ts
+++ b/src/core/types/security.type.ts
@@ -1,0 +1,14 @@
+/**
+ * KRX에서 받은 CSV 데이터 한 행의 타입을 정의합니다.
+ */
+export interface RawKrxRow {
+  종목코드: string;
+  종목명: string;
+  시장구분: string;
+  종가: string;
+  대비: string;
+  등락률: string;
+  시가총액: string;
+  거래량: string;
+  [key: string]: string; // 그 외 예상치 못한 컬럼이 있을 수 있음을 명시
+}


### PR DESCRIPTION
## Result
- 시장 전체 보기`(/market)` 페이지 진입 시, 우측에 rss feed 목록이 나오도록 기능 추가

## Work list
- rss feed 목록 관련 xml을 받아온 뒤 이를 parsing 하여 활용
- 서버 config를 활용하여 받아올 신문 데이터를 제어할 수 있으며, 클라이언트에서 http 요청 시 query string을 활용하여 제어 가능
- 이외에 기존에 테스트 페이지에 있던 kospi 종목 데이터 조회 기능을 market 페이지로 이동 처리

## Discussion
- 현재 언론 데이터 확보를 위해 rss feed를 활용 중에 있으나, 자료 조사 중 더 나은 외부 리소스`(bigkinds)`를 발견하여 추후 교체 예정
