### PR TITLE
feat: PER/PBR 필터 비활성화로 대형주 포함

### DIFF
--- a/src/core/services/stock-signal-screening.service.ts
+++ b/src/core/services/stock-signal-screening.service.ts
@@ -59,8 +59,8 @@ export const SCREENING_CONFIG: ScreeningConfig = {
     minROE: 5,
     maxDebtRatio: 200,
     minOperatingMargin: 3,
-    maxPER: 30,
-    maxPBR: 3.0,
+    maxPER: null, // 필터 비활성화 (대형주 포함)
+    maxPBR: null, // 필터 비활성화 (대형주 포함)
   },
   topN: 40,
 };


### PR DESCRIPTION
## Result
- 선별 종목 필터링 시, 거래량이 많은 대형주 위주로 필터링 되도록 config 설정 변경

## Work list
- maxPER, maxPBR을 null로 설정하여 필터 비활성화
- 시가총액 상위 40개 선택으로 대형주/우량주 위주 스크리닝
- 펀더멘털 건전성 유지 (ROE, 부채비율, 영업이익률)

## Discussion
