### PR TITLE
fix: KIS WebSocket 연결 안정성 개선 및 rate limiting 방지

### DIFF
--- a/src/core/services/stock-signal-screening.service.ts
+++ b/src/core/services/stock-signal-screening.service.ts
@@ -62,7 +62,7 @@ export const SCREENING_CONFIG: ScreeningConfig = {
     maxPER: null, // 필터 비활성화 (대형주 포함)
     maxPBR: null, // 필터 비활성화 (대형주 포함)
   },
-  topN: 40,
+  topN: 30, // KIS WebSocket rate limiting 방지 (이전: 40)
 };
 
 // ============================================================================


### PR DESCRIPTION
## Result
- 배포 환경에서 KIS WebSocket 연결이 끊어진 후 재연결 실패 문제 해결
- 이벤트 리스너 중복으로 인한 무한 재연결 루프 제거, 장중 연결 보장
- rate limiting 방지 적용 

## Work lists
  - 이벤트 리스너 중복 제거 (`cleanupConnection()`, `isReconnecting` 플래그)
  - 장중(09:00-15:30) 무한 재연결, 장 마감 후 5회 제한
  - Exponential backoff 적용 (5초 → 10초 → 20초 → 40초 → 최대 60초)
  - 구독 요청 throttling 추가 (50ms 간격)
  - Health Check 강화: 장중 5분마다 연결 모니터링
  - 스크리닝 종목 수 40개 → 30개 감소

## Discussion
